### PR TITLE
fix: removeAllListeners中events应为对象

### DIFF
--- a/src/emitter.js
+++ b/src/emitter.js
@@ -60,7 +60,7 @@ class Emitter {
 
     removeAllListeners(event) {
         if (!event) {
-            this._events = [];
+            this._events = {};
         } else {
             delete this._events[event.toLowerCase()];
         }


### PR DESCRIPTION
this._events为对象会更加严谨些